### PR TITLE
Fix Linux build

### DIFF
--- a/Sources/Tuxedo/StandardLibrary_Functions.swift
+++ b/Sources/Tuxedo/StandardLibrary_Functions.swift
@@ -669,6 +669,7 @@ public extension StandardLibrary {
         }
     }
 
+#if !os(Linux)
     static var methodCallWithIntResult: Function<Double> {
         return Function([Variable<Any>("lhs"), Keyword("."), Variable<String>("rhs", options: .notInterpreted)]) {
             if let lhs = $0.variables["lhs"] as? NSObjectProtocol,
@@ -679,5 +680,7 @@ public extension StandardLibrary {
             return nil
         }
     }
+#endif
+
 }
 //swiftlint:disable:this file_length


### PR DESCRIPTION
Currently the build on Linux/Docker fails because "Selector" is not available on Linux. Since the static property methodCallWithIntResult: is not actively been used, we could just exclude it on Linux